### PR TITLE
fix: `ESC`按键事件污染

### DIFF
--- a/src/img-preview.vue
+++ b/src/img-preview.vue
@@ -13,8 +13,6 @@
 <script>
 import computedSize from './utils'
 
-const KEY_CODE_ESC = 27
-
 export default {
   name: 'ImgPreview',
   model: {
@@ -60,10 +58,8 @@ export default {
       this.$emit('close')
     },
     handelKeyUp(event) {
-      switch (event.keyCode) {
-        case KEY_CODE_ESC:
-          if (this.url) this.handleClose()
-          break
+      if (event.key === 'Escape' && this.url) {
+        this.handleClose()
       }
     }
   }

--- a/src/img-preview.vue
+++ b/src/img-preview.vue
@@ -62,7 +62,7 @@ export default {
     handelKeyUp(event) {
       switch (event.keyCode) {
         case KEY_CODE_ESC:
-          this.handleClose()
+          if (this.url) this.handleClose()
           break
       }
     }


### PR DESCRIPTION
fix #14 
## How
仅在当前组件preview图片时，相应escape键事件