### PR TITLE
Feature: 滚轮控制缩放，拖动图片查看

### DIFF
--- a/src/img-preview.vue
+++ b/src/img-preview.vue
@@ -117,7 +117,7 @@ export default {
       this.distanceY = e.clientY - this.startY
     },
     handleImgScale(e) {
-      const delta = e.wheelDelta || -event.detail * 24 // // 兼容火狐
+      const delta = e.wheelDelta || -e.detail * 24 // // 兼容火狐
       if (delta < 0) {
         this.size.scale += 0.1
       } else {

--- a/src/img-preview.vue
+++ b/src/img-preview.vue
@@ -121,6 +121,7 @@ export default {
       if (delta < 0) {
         this.size.scale += 0.1
       } else {
+        if (this.size.scale <= 0.5) return
         this.size.scale -= 0.1
       }
     },


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits

- feat: A new feature 
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing or correcting existing tests
- chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

## Why
之前遇到一个问题，某些图片的尺寸在放大后 scale 固定为1，在视觉上看起来比原图还小，且不能缩放，所以就加一个滚轮控制缩放，然后又遇到放到很大之后，图片会超出屏幕，所以加了拖动图片查看

## How
Describe your steps:
1. 点开图片
2. 滚轮控制缩放
3. 拖动图片查看
4. 点击遮罩关闭
5. 点击右上角关闭按钮关闭

## Demo
![img-preview-480](https://user-images.githubusercontent.com/14030995/65037992-7ea10080-d981-11e9-9c0f-f5501d172315.gif)

