### PR TITLE
feat: v-img-preview 指令支持指令参数

### DIFF
--- a/docs/directive.md
+++ b/docs/directive.md
@@ -2,6 +2,17 @@
 
 ```vue
 <template>
-  <img v-img-preview width="100px" src="https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_Deepexi_640x640.jpg" >
+  <div>
+    <p>默认指令</p>
+    <img v-img-preview width="100px" src="https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_Deepexi_640x640.jpg" >
+
+    <p>带参数的指令:预览时为 webp 图</p>
+    <img
+      v-img-preview:webp-src
+      width="100px"
+      src="https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_Deepexi_640x640.jpg"
+      webp-src="https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_Deepexi_640x640.jpg?x-oss-process=image/format,webp"
+    >
+  </div>
 </template>
 ```

--- a/docs/directive.md
+++ b/docs/directive.md
@@ -3,10 +3,11 @@
 ```vue
 <template>
   <div>
-    <p>默认指令</p>
+    <h3>默认指令</h3>
     <img v-img-preview width="100px" src="https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_Deepexi_640x640.jpg" >
 
-    <p>带参数的指令:预览时为 webp 图</p>
+    <h3>带参数的指令:预览时为 webp 图</h3>
+    <p>PS: 这个参数是 html 的 attribute</p>
     <img
       v-img-preview:webp-src
       width="100px"

--- a/src/directive.js
+++ b/src/directive.js
@@ -14,7 +14,7 @@ previewDirective.install = Vue => {
   }
 
   Vue.directive('img-preview', {
-    bind(el) {
+    bind(el, {arg}) {
       const preview = new Preview({el})
 
       preview.$on('input', url => {
@@ -27,7 +27,7 @@ previewDirective.install = Vue => {
       el.style.cursor = 'zoom-in'
 
       el.addEventListener('click', () => {
-        togglePreview(el, el.getAttribute('src'))
+        togglePreview(el, el.getAttribute(arg || 'src'))
       })
     },
 


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

链接 PR https://github.com/FEMessage/v-img/pull/19
组合功能👊

## Why

- 场景是, 页面默认加载的是小图, 点击预览加载"大"图, 因此需要提供一些额外的属性用于保存大图 url
- ~~暗示 v-img~~

## QA

- Q 为何要使用属性而不使用 指令值
- A 其实也存在私心, 为了获取 @femessage/v-img 组件 的未裁剪过的 url

## How to use

- `v-img-preview:high-quality-src`
  - 当然它可以是任何已存在元素上的属性

```diff
 <template>
   <img
-    v-img-preview
+    v-img-preview:high-quality-src
     src="https://image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg"
     high-quality-src="https://image-demo.oss-cn-hangzhou.aliyuncs.com/example@2x.jpg"
   >
 </template>
```

## Test

无测试相关文件改动

## Docs

- directive.md 添加可选参数示例
